### PR TITLE
Update ROS apt key to fix CI

### DIFF
--- a/mps_shape_completion/docker/Dockerfile
+++ b/mps_shape_completion/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM tensorflow/tensorflow:1.7.0
 
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 RUN apt-get -yq update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yqq install \


### PR DESCRIPTION
Build tests passed on TravisCI