### PR TITLE
Make compatible with TF2 using tensorflow.compat.v1

### DIFF
--- a/mps_shape_completion/docker/Dockerfile
+++ b/mps_shape_completion/docker/Dockerfile
@@ -1,16 +1,17 @@
 FROM tensorflow/tensorflow:1.15.0
 
+RUN apt-get -yq install lsb-release
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 RUN apt-get -yq update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yqq install \
-    ros-kinetic-ros-base \
+    ros-melodic-ros-base \
     gcovr \
     ccache && \
     rm -rf /var/lib/apt/lists/*
 
-RUN echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
+RUN echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
 
 RUN mkdir -p ~/catkin_ws/src/

--- a/mps_shape_completion/docker/Dockerfile
+++ b/mps_shape_completion/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.7.0
+FROM tensorflow/tensorflow:1.15.0
 
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 

--- a/mps_shape_completion/docker/setup.sh
+++ b/mps_shape_completion/docker/setup.sh
@@ -1,5 +1,5 @@
 #/bin/bash
 
-. /opt/ros/kinetic/setup.bash
+. /opt/ros/melodic/setup.bash
 pyclean .
 catkin_make

--- a/mps_shape_completion/docker/test.sh
+++ b/mps_shape_completion/docker/test.sh
@@ -1,5 +1,5 @@
 #/bin/bash
 
-. /opt/ros/kinetic/setup.bash
+. /opt/ros/melodic/setup.bash
 . /root/catkin_ws/devel/setup.bash
 catkin_make run_tests && catkin_test_results

--- a/mps_shape_completion/shape_complete.py
+++ b/mps_shape_completion/shape_complete.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import time
 # config
 GPU0 = '/gpu:0'
@@ -13,6 +13,7 @@ class ShapeCompleter():
         Constructor of the Shape_complete class. Load the model from 'model_path'.
         INPUT: verbose: print messages for debug
         '''
+        tf.disable_v2_behavior()
         if not verbose:
             os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3' 
             tf.logging.set_verbosity(tf.logging.FATAL)

--- a/mps_shape_completion/shape_completion_node.py
+++ b/mps_shape_completion/shape_completion_node.py
@@ -58,6 +58,7 @@ def listener():
 
     pub = rospy.Publisher('local_occupancy_predicted', numpy_msg(Float32MultiArray), queue_size=10)
     rospy.Subscriber("local_occupancy", numpy_msg(Float32MultiArray), callback, (sc, pub))
+    rospy.loginfo("Shape completer ready")
     rospy.spin()
 
 


### PR DESCRIPTION
This commit makes the shape completer compatible with both v1.15 and v2.0 of tensorflow. 

@a-price Please test on your system to make sure it still runs fine