### PR TITLE
Added an RViz Plugin for visualizing voxel grids

### DIFF
--- a/mps_shape_completion/docker/Dockerfile
+++ b/mps_shape_completion/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6
 
 RUN apt-get -yq update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yqq install \
-    ros-kinetic-ros-base \
+    ros-melodic-desktop \
     gcovr \
     ccache && \
     rm -rf /var/lib/apt/lists/*

--- a/mps_shape_completion_visualization/CMakeLists.txt
+++ b/mps_shape_completion_visualization/CMakeLists.txt
@@ -1,104 +1,35 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mps_shape_completion_visualization)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED
-  mps_shape_completion_msgs)
+  mps_shape_completion_msgs
+  rviz
+  roscpp)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+set(QT_LIBRARIES Qt5::Widgets)
+
+set(CMAKE_AUTOMOC ON)
+
+set(SRC_FILES
+  src/voxel_display.cpp
+  src/voxel_visual.cpp
+  )
+
+
+
 catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
 
 ###################################
 ## catkin specific configuration ##
 ###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES mps_shape_completion_visualization
@@ -113,91 +44,33 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
-# ${catkin_INCLUDE_DIRS}
+include
+${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/mps_shape_completion_visualization.cpp
-# )
+add_library(${PROJECT_NAME}
+  ${SRC_FILES}
+  )
 
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}
+  ${QT_LIBRARIES}
+  ${catkin_LIBRARES}
+  )
 
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/mps_shape_completion_visualization_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
 
 #############
 ## Install ##
 #############
 
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+install(TARGETS
+  ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(FILES
+  plugin_description.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-## Mark executables for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
-# install(TARGETS ${PROJECT_NAME}_node
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark libraries for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-# install(TARGETS ${PROJECT_NAME}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_mps_shape_completion_visualization.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/mps_shape_completion_visualization/CMakeLists.txt
+++ b/mps_shape_completion_visualization/CMakeLists.txt
@@ -44,8 +44,9 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-include
-${catkin_INCLUDE_DIRS}
+  include
+  SYSTEM
+  ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library

--- a/mps_shape_completion_visualization/package.xml
+++ b/mps_shape_completion_visualization/package.xml
@@ -32,7 +32,7 @@
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
   <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
+  <depend>roscpp</depend>
   <!--   Note that this is equivalent to the following: -->
   <!--   <build_depend>roscpp</build_depend> -->
   <!--   <exec_depend>roscpp</exec_depend> -->
@@ -48,6 +48,10 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
+  <depend>libqt5-core</depend>
+  <depend>libqt5-gui</depend>
+  <depend>libqt5-widgets</depend>
+  <depend>rviz</depend>
   
   <buildtool_depend>catkin</buildtool_depend>
 
@@ -57,7 +61,6 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <rviz plugin="${prefix}/plugin_description.xml"/>
   </export>
 </package>

--- a/mps_shape_completion_visualization/plugin_description.xml
+++ b/mps_shape_completion_visualization/plugin_description.xml
@@ -1,0 +1,10 @@
+<library path="lib/libmps_shape_completion_visualization">
+  <class name="mps_shape_completion_visualization/VoxelGrid"
+         type="mps_shape_completion_visualization::VoxelGridDisplay"
+         base_class_type="rviz::Display">
+    <description>
+      Displays a Voxel Grid
+    </description>
+    <message_type>mps_shape_completion_msgs/OccupancyStamped</message_type>
+  </class>
+</library>

--- a/mps_shape_completion_visualization/src/voxel_display.cpp
+++ b/mps_shape_completion_visualization/src/voxel_display.cpp
@@ -1,0 +1,116 @@
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+
+#include <tf/transform_listener.h>
+
+#include <rviz/visualization_manager.h>
+#include <rviz/properties/color_property.h>
+#include <rviz/properties/float_property.h>
+#include <rviz/properties/int_property.h>
+#include <rviz/frame_manager.h>
+
+#include "voxel_visual.h"
+
+#include "voxel_display.h"
+
+namespace mps_shape_completion_visualization
+{
+
+// The constructor must have no arguments, so we can't give the
+// constructor the parameters it needs to fully initialize.
+    VoxelGridDisplay::VoxelGridDisplay()
+    {
+        color_property_ = new rviz::ColorProperty( "Color", QColor( 204, 51, 204 ),
+                                                   "Color to draw the acceleration arrows.",
+                                                   this, SLOT( updateColorAndAlpha() ));
+
+        alpha_property_ = new rviz::FloatProperty( "Alpha Multiple", 1.0,
+                                                   "0 is fully transparent, 1.0 is fully opaque.",
+                                                   this, SLOT( updateColorAndAlpha() ));
+
+
+        binary_display_property_ = new rviz::BoolProperty("Binary Display", true,
+                                                          "If checked, all voxels will have the same alpha",
+                                                          this, SLOT(updateColorAndAlpha() ));
+
+        cutoff_property_ = new rviz::FloatProperty("Threshold", 0.5,
+                                                   "Voxels with values less than this will not be displayed",
+                                                   this, SLOT(updateColorAndAlpha() ));
+
+
+    }
+
+// After the top-level rviz::Display::initialize() does its own setup,
+// it calls the subclass's onInitialize() function.  This is where we
+// instantiate all the workings of the class.  We make sure to also
+// call our immediate super-class's onInitialize() function, since it
+// does important stuff setting up the message filter.
+//
+//  Note that "MFDClass" is a typedef of
+// ``MessageFilterDisplay<message type>``, to save typing that long
+// templated class name every time you need to refer to the
+// superclass.
+    void VoxelGridDisplay::onInitialize()
+    {
+        MFDClass::onInitialize();
+        visual_.reset(new VoxelGridVisual( context_->getSceneManager(), scene_node_ ));
+        updateColorAndAlpha();
+    }
+
+    VoxelGridDisplay::~VoxelGridDisplay()
+    {
+    }
+
+    void VoxelGridDisplay::reset()
+    {
+        MFDClass::reset();
+    }
+
+// Set the current color and alpha values for each visual.
+    void VoxelGridDisplay::updateColorAndAlpha()
+    {
+        float alpha = alpha_property_->getFloat();
+        Ogre::ColourValue color = color_property_->getOgreColor();
+        visual_->setBinaryDisplay(binary_display_property_->getBool());
+        visual_->setColor( color.r, color.g, color.b, alpha );
+        visual_->setThreshold(cutoff_property_->getFloat());
+        visual_->updatePointCloud();
+    }
+
+
+// This is our callback to handle an incoming message.
+    void VoxelGridDisplay::processMessage( const mps_shape_completion_msgs::OccupancyStamped::ConstPtr& msg)
+    {
+        // Here we call the rviz::FrameManager to get the transform from the
+        // fixed frame to the frame in the header of this Imu message.  If
+        // it fails, we can't do anything else so we return.
+        Ogre::Quaternion orientation;
+        Ogre::Vector3 position;
+        if( !context_->getFrameManager()->getTransform( msg->header.frame_id,
+                                                        msg->header.stamp,
+                                                        position, orientation ))
+        {
+            ROS_DEBUG( "Error transforming from frame '%s' to frame '%s'",
+                       msg->header.frame_id.c_str(), qPrintable( fixed_frame_ ));
+            return;
+        }
+
+
+        // Now set or update the contents of the chosen visual.
+        visual_->setMessage( msg );
+        visual_->setFramePosition( position );
+        visual_->setFrameOrientation( orientation );
+
+    }
+
+
+    
+} // end namespace mps_shape_completion_visualization
+
+
+
+// Tell pluginlib about this class.  It is important to do this in
+// global scope, outside our package's namespace.
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(mps_shape_completion_visualization::VoxelGridDisplay, rviz::Display )
+

--- a/mps_shape_completion_visualization/src/voxel_display.cpp
+++ b/mps_shape_completion_visualization/src/voxel_display.cpp
@@ -20,24 +20,25 @@ namespace mps_shape_completion_visualization
 // constructor the parameters it needs to fully initialize.
     VoxelGridDisplay::VoxelGridDisplay()
     {
-        color_property_ = new rviz::ColorProperty( "Color", QColor( 204, 51, 204 ),
-                                                   "Color to draw the acceleration arrows.",
-                                                   this, SLOT( updateColorAndAlpha() ));
+        color_property_ = std::make_unique<rviz::ColorProperty>(
+            "Color", QColor( 204, 51, 204 ),
+            "Color to draw the acceleration arrows.",
+            this, SLOT( updateColorAndAlpha() ));
 
-        alpha_property_ = new rviz::FloatProperty( "Alpha Multiple", 1.0,
-                                                   "0 is fully transparent, 1.0 is fully opaque.",
-                                                   this, SLOT( updateColorAndAlpha() ));
+        alpha_property_ = std::make_unique<rviz::FloatProperty>(
+            "Alpha", 1.0,
+            "0 is fully transparent, 1.0 is fully opaque.",
+            this, SLOT( updateColorAndAlpha() ));
 
+        binary_display_property_ = std::make_unique<rviz::BoolProperty>(
+            "Binary Display", true,
+            "If checked, all voxels will have the same alpha",
+            this, SLOT(updateColorAndAlpha() ));
 
-        binary_display_property_ = new rviz::BoolProperty("Binary Display", true,
-                                                          "If checked, all voxels will have the same alpha",
-                                                          this, SLOT(updateColorAndAlpha() ));
-
-        cutoff_property_ = new rviz::FloatProperty("Threshold", 0.5,
-                                                   "Voxels with values less than this will not be displayed",
-                                                   this, SLOT(updateColorAndAlpha() ));
-
-
+        cutoff_property_ = std::make_unique<rviz::FloatProperty>(
+            "Threshold", 0.5,
+            "Voxels with values less than this will not be displayed",
+            this, SLOT(updateColorAndAlpha() ));
     }
 
 // After the top-level rviz::Display::initialize() does its own setup,
@@ -95,15 +96,11 @@ namespace mps_shape_completion_visualization
             return;
         }
 
-
         // Now set or update the contents of the chosen visual.
         visual_->setMessage( msg );
         visual_->setFramePosition( position );
         visual_->setFrameOrientation( orientation );
-
     }
-
-
     
 } // end namespace mps_shape_completion_visualization
 

--- a/mps_shape_completion_visualization/src/voxel_display.h
+++ b/mps_shape_completion_visualization/src/voxel_display.h
@@ -1,0 +1,68 @@
+#ifndef VOXEL_DISPLAY_H
+#define VOXEL_DISPLAY_H
+
+#include <boost/circular_buffer.hpp>
+
+#include <mps_shape_completion_msgs/OccupancyStamped.h>
+#include <rviz/message_filter_display.h>
+
+namespace Ogre
+{
+class SceneNode;
+}
+
+namespace rviz
+{
+class ColorProperty;
+class FloatProperty;
+class IntProperty;
+}
+
+namespace mps_shape_completion_visualization
+{
+
+class VoxelGridVisual;
+
+class VoxelGridDisplay: public rviz::MessageFilterDisplay<mps_shape_completion_msgs::OccupancyStamped>
+{
+Q_OBJECT
+public:
+  // Constructor.  pluginlib::ClassLoader creates instances by calling
+  // the default constructor, so make sure you have one.
+  VoxelGridDisplay();
+  virtual ~VoxelGridDisplay();
+
+  // Overrides of protected virtual functions from Display.  As much
+  // as possible, when Displays are not enabled, they should not be
+  // subscribed to incoming data and should not show anything in the
+  // 3D view.  These functions are where these connections are made
+  // and broken.
+protected:
+  virtual void onInitialize();
+
+  // A helper to clear this display back to the initial state.
+  virtual void reset();
+
+  // These Qt slots get connected to signals indicating changes in the user-editable properties.
+private Q_SLOTS:
+  void updateColorAndAlpha();
+
+
+private:
+  // Function to handle an incoming ROS message.
+  void processMessage( const mps_shape_completion_msgs::OccupancyStamped::ConstPtr& msg);
+
+  // Storage for the list of visuals.  It is a circular buffer where
+  // data gets popped from the front (oldest) and pushed to the back (newest)
+  boost::shared_ptr<VoxelGridVisual > visual_;
+
+  // User-editable property variables.
+  rviz::ColorProperty* color_property_;
+  rviz::FloatProperty* alpha_property_;
+  rviz::BoolProperty* binary_display_property_;
+  rviz::FloatProperty* cutoff_property_;
+};
+
+} // end namespace mps_shape_completion_visualization
+
+#endif // VOXEL_DISPLAY_H

--- a/mps_shape_completion_visualization/src/voxel_display.h
+++ b/mps_shape_completion_visualization/src/voxel_display.h
@@ -1,8 +1,6 @@
 #ifndef VOXEL_DISPLAY_H
 #define VOXEL_DISPLAY_H
 
-#include <boost/circular_buffer.hpp>
-
 #include <mps_shape_completion_msgs/OccupancyStamped.h>
 #include <rviz/message_filter_display.h>
 
@@ -23,6 +21,7 @@ namespace mps_shape_completion_visualization
 
 class VoxelGridVisual;
 
+// TODO: inheriting from MessageFilterDisplay gives us topic handling (yay!), but also the undesirable "unreliabel" checkbox. 
 class VoxelGridDisplay: public rviz::MessageFilterDisplay<mps_shape_completion_msgs::OccupancyStamped>
 {
 Q_OBJECT
@@ -52,15 +51,13 @@ private:
   // Function to handle an incoming ROS message.
   void processMessage( const mps_shape_completion_msgs::OccupancyStamped::ConstPtr& msg);
 
-  // Storage for the list of visuals.  It is a circular buffer where
-  // data gets popped from the front (oldest) and pushed to the back (newest)
-  boost::shared_ptr<VoxelGridVisual > visual_;
+  std::unique_ptr<VoxelGridVisual > visual_;
 
   // User-editable property variables.
-  rviz::ColorProperty* color_property_;
-  rviz::FloatProperty* alpha_property_;
-  rviz::BoolProperty* binary_display_property_;
-  rviz::FloatProperty* cutoff_property_;
+  std::unique_ptr<rviz::ColorProperty> color_property_;
+  std::unique_ptr<rviz::FloatProperty> alpha_property_;
+  std::unique_ptr<rviz::BoolProperty> binary_display_property_;
+  std::unique_ptr<rviz::FloatProperty> cutoff_property_;
 };
 
 } // end namespace mps_shape_completion_visualization

--- a/mps_shape_completion_visualization/src/voxel_visual.cpp
+++ b/mps_shape_completion_visualization/src/voxel_visual.cpp
@@ -1,0 +1,128 @@
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+
+#include <rviz/ogre_helpers/point_cloud.h>
+#include <std_msgs/Float32MultiArray.h>
+
+#include "voxel_visual.h"
+
+namespace mps_shape_completion_visualization
+{
+
+// BEGIN_TUTORIAL
+    VoxelGridVisual::VoxelGridVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node )
+    {
+        scene_manager_ = scene_manager;
+
+        frame_node_ = parent_node->createChildSceneNode();
+
+        // We create the arrow object within the frame node so that we can
+        // set its position and direction relative to its header frame.
+        // voxel_grid_.reset(new rviz::PointCloud( scene_manager_, frame_node_ ));
+        voxel_grid_.reset(new rviz::PointCloud());
+        voxel_grid_->setRenderMode(rviz::PointCloud::RM_BOXES);
+        frame_node_->attachObject(voxel_grid_.get());
+    }
+
+    VoxelGridVisual::~VoxelGridVisual()
+    {
+        // Destroy the frame node since we don't need it anymore.
+        scene_manager_->destroySceneNode( frame_node_ );
+    }
+
+    void VoxelGridVisual::setMessage( const mps_shape_completion_msgs::OccupancyStamped::ConstPtr& msg)
+    {
+        latest_msg = *msg;
+        updatePointCloud();
+    }
+
+    void VoxelGridVisual::updatePointCloud()
+    {
+        if(latest_msg.occupancy.layout.dim.size() == 0)
+        {
+            return;
+        }
+        
+        double scale = latest_msg.scale;
+        voxel_grid_->setDimensions(scale, scale, scale);
+
+
+        const std::vector<float> data = latest_msg.occupancy.data;
+        const std::vector<std_msgs::MultiArrayDimension> dims = latest_msg.occupancy.layout.dim;
+        int data_offset = latest_msg.occupancy.layout.data_offset;
+
+        std::vector< rviz::PointCloud::Point> points;
+        for(int i=0; i<dims[0].size; i++)
+        {
+            for(int j=0; j<dims[1].size; j++)
+            {
+                for(int k=0; k<dims[2].size; k++)
+                {
+                    float val = data[data_offset + dims[1].stride * i + dims[2].stride * j + k];
+                    if(val < threshold_)
+                    {
+                        continue;
+                    }
+                    
+                    rviz::PointCloud::Point p;
+                    p.position.x = scale/2 + i*scale;
+                    p.position.y = scale/2 + j*scale;
+                    p.position.z = scale/2 + k*scale;
+
+
+                    if(binary_display_)
+                    {
+                        val = 1.0;
+                    }
+
+                    p.setColor(r_, g_, b_, val*a_);
+                    
+                    points.push_back(p);
+                }
+            }
+        }
+        
+        voxel_grid_->clear();
+
+        //The per-point alpha setting is not great with alpha=1, so in
+        // certain cases do not use it
+        bool use_per_point = !(a_ >= 1.0 && binary_display_);
+        voxel_grid_->setAlpha(a_, use_per_point);
+        
+        voxel_grid_->addPoints(&points.front(), points.size());
+
+    }
+
+
+
+// Position and orientation are passed through to the SceneNode.
+    void VoxelGridVisual::setFramePosition( const Ogre::Vector3& position )
+    {
+        frame_node_->setPosition( position );
+    }
+
+    void VoxelGridVisual::setFrameOrientation( const Ogre::Quaternion& orientation )
+    {
+        frame_node_->setOrientation( orientation );
+    }
+
+    void VoxelGridVisual::setColor( float r, float g, float b, float a )
+    {
+        r_ = r;
+        g_ = g;
+        b_ = b;
+        a_ = a;
+    }
+
+    void VoxelGridVisual::setBinaryDisplay(bool binary_display)
+    {
+        binary_display_ = binary_display;
+    }
+
+    void VoxelGridVisual::setThreshold(float threshold)
+    {
+        threshold_ = threshold;
+    }
+
+} // end namespace mps_shape_completion_visualization

--- a/mps_shape_completion_visualization/src/voxel_visual.cpp
+++ b/mps_shape_completion_visualization/src/voxel_visual.cpp
@@ -9,8 +9,6 @@
 
 namespace mps_shape_completion_visualization
 {
-
-// BEGIN_TUTORIAL
     VoxelGridVisual::VoxelGridVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node )
     {
         scene_manager_ = scene_manager;
@@ -33,24 +31,24 @@ namespace mps_shape_completion_visualization
 
     void VoxelGridVisual::setMessage( const mps_shape_completion_msgs::OccupancyStamped::ConstPtr& msg)
     {
-        latest_msg = *msg;
+        latest_msg = msg;
         updatePointCloud();
     }
 
     void VoxelGridVisual::updatePointCloud()
     {
-        if(latest_msg.occupancy.layout.dim.size() == 0)
+        if(!latest_msg)
         {
             return;
         }
         
-        double scale = latest_msg.scale;
+        double scale = latest_msg->scale;
         voxel_grid_->setDimensions(scale, scale, scale);
 
 
-        const std::vector<float> data = latest_msg.occupancy.data;
-        const std::vector<std_msgs::MultiArrayDimension> dims = latest_msg.occupancy.layout.dim;
-        int data_offset = latest_msg.occupancy.layout.data_offset;
+        const std::vector<float> data = latest_msg->occupancy.data;
+        const std::vector<std_msgs::MultiArrayDimension> dims = latest_msg->occupancy.layout.dim;
+        int data_offset = latest_msg->occupancy.layout.data_offset;
 
         std::vector< rviz::PointCloud::Point> points;
         for(int i=0; i<dims[0].size; i++)
@@ -64,20 +62,17 @@ namespace mps_shape_completion_visualization
                     {
                         continue;
                     }
-                    
-                    rviz::PointCloud::Point p;
-                    p.position.x = scale/2 + i*scale;
-                    p.position.y = scale/2 + j*scale;
-                    p.position.z = scale/2 + k*scale;
-
-
                     if(binary_display_)
                     {
                         val = 1.0;
                     }
 
+                    rviz::PointCloud::Point p;
+                    p.position.x = scale/2 + i*scale;
+                    p.position.y = scale/2 + j*scale;
+                    p.position.z = scale/2 + k*scale;
+
                     p.setColor(r_, g_, b_, val*a_);
-                    
                     points.push_back(p);
                 }
             }

--- a/mps_shape_completion_visualization/src/voxel_visual.h
+++ b/mps_shape_completion_visualization/src/voxel_visual.h
@@ -1,0 +1,73 @@
+#ifndef VOXEL_VISUAL_H
+#define VOXEL_VISUAL_H
+
+#include <mps_shape_completion_msgs/OccupancyStamped.h>
+
+
+namespace Ogre
+{
+class Vector3;
+class Quaternion;
+}
+
+namespace rviz
+{
+class PointCloud;
+}
+
+namespace mps_shape_completion_visualization
+{
+
+class VoxelGridVisual
+{
+public:
+  // Constructor.  Creates the visual stuff and puts it into the
+  // scene, but in an unconfigured state.
+  VoxelGridVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node );
+
+  // Destructor.  Removes the visual stuff from the scene.
+  virtual ~VoxelGridVisual();
+
+  // Configure the visual to show the data in the message.
+  void setMessage( const mps_shape_completion_msgs::OccupancyStamped::ConstPtr& msg);
+
+  void setFramePosition( const Ogre::Vector3& position );
+  void setFrameOrientation( const Ogre::Quaternion& orientation );
+
+  // Set the color and alpha of the visual, which are user-editable
+  // parameters and therefore don't come from the Imu message.
+  void setColor( float r, float g, float b, float a );
+
+  void setBinaryDisplay(bool use_global_alpha);
+  void setThreshold(float threshold);
+
+  //Rerenders the point cloud from the list of points and UI-selected properties
+  void updatePointCloud();
+
+private:
+
+  // A local copy of the message is stored so that the voxelgrid can be
+  // regenerated if the user changes the input
+  mps_shape_completion_msgs::OccupancyStamped latest_msg;
+  
+  // The visible voxel grid ogre object
+  boost::shared_ptr<rviz::PointCloud> voxel_grid_;
+
+  // A SceneNode whose pose is set to match the coordinate frame of
+  Ogre::SceneNode* frame_node_;
+
+  // The SceneManager, kept here only so the destructor can ask it to
+  // destroy the ``frame_node_``.
+  Ogre::SceneManager* scene_manager_;
+
+  // User settings
+  float r_, g_, b_, a_;
+  bool binary_display_;
+  float threshold_;
+  
+};
+// END_TUTORIAL
+
+} // end namespace mps_shape_completion_visualization
+
+#endif // VOXEL_VISUAL_H

--- a/mps_shape_completion_visualization/src/voxel_visual.h
+++ b/mps_shape_completion_visualization/src/voxel_visual.h
@@ -48,10 +48,10 @@ private:
 
   // A local copy of the message is stored so that the voxelgrid can be
   // regenerated if the user changes the input
-  mps_shape_completion_msgs::OccupancyStamped latest_msg;
+  mps_shape_completion_msgs::OccupancyStamped::ConstPtr latest_msg;
   
   // The visible voxel grid ogre object
-  boost::shared_ptr<rviz::PointCloud> voxel_grid_;
+  std::shared_ptr<rviz::PointCloud> voxel_grid_;
 
   // A SceneNode whose pose is set to match the coordinate frame of
   Ogre::SceneNode* frame_node_;
@@ -66,7 +66,6 @@ private:
   float threshold_;
   
 };
-// END_TUTORIAL
 
 } // end namespace mps_shape_completion_visualization
 


### PR DESCRIPTION
I wrote the RViz Plugin to visualize voxel grids. This would have saved me so much time over the past 2 years.
https://www.youtube.com/watch?v=RjPO3k0jobE&feature=youtu.be

@a-price @dmcconachie You both might be interested.

The benefits:  Visualization is decoupled from data
1) The voxel grid is stored by the plugin. You do not need to wait for a new message to make visualization changes
2) You can rosbag the voxelgrids and change visualization later
3) You can change alpha, color, threshold for visualizing, and binary vs continuous alpha display directly in RViz. No need to recompile.



FYI, the TravisCI build tests fail because of the new dependency on Qt. An `apt install` would fix it, but really the we should do a `rosdep install`. I haven't figured all that out inside the docker file yet.
We should merge the other pull requests first:
https://github.com/UM-ARM-Lab/mps_shape_completion/pull/7
https://github.com/UM-ARM-Lab/mps_shape_completion/pull/8

